### PR TITLE
Init null object

### DIFF
--- a/lib/gtfs.js
+++ b/lib/gtfs.js
@@ -287,7 +287,10 @@ module.exports = {
         match.route_type = undefined;
         next()
       }, function (error) {
+        // TEMPORARY PATCH TO PREVENT THE SERVER FROM CRASHING
+        origin_stop = origin_stop || {};
         origin_stop.zone_id = undefined;
+        destination_stop = destination_stop || {};
         destination_stop.zone_id = undefined;
         final_result = {stops: {origin: origin_stop, destination: destination_stop}, departures: matches};
         cb(error);


### PR DESCRIPTION
Since `cb` is called with `cb(err, final_result)` and final_result is set in the error case, I suspect it might be used. Haven't investigated.

Seems to fix a few alerts
- https://www.flowdock.com/app/busbud/integrations/threads/cIuKUk-Q3TUosWmVacXGv7PiqKs
- https://www.flowdock.com/app/busbud/devs/threads/3XGRn79H--Cyi-BuslAc9CfsU9I
